### PR TITLE
docs(readme): added clarification about Base branding usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,3 +46,6 @@ Located in [/fonts](fonts/).
 | ![SymbolBlue](logo/TheSquare/Digital/Base_square_blue.svg)   | ![WordmarkBlue](logo/Basemark/Digital/Base_basemark_blue.svg)   |
 | ![SymbolWhite](logo/TheSquare/Digital/Base_square_white.svg)   | ![WordmarkWhite](logo/Basemark/Digital/Base_basemark_white.svg)   |
 | ![SymbolBlack](logo/TheSquare/Digital/Base_square_black.svg)   | ![WordmarkBlack](logo/Basemark/Digital/Base_basemark_black.svg)   |
+
+> Minor documentation clarification by contributor damir024.
+


### PR DESCRIPTION
Added a short note to README.md to improve clarity and structure for contributors working with Base brand assets.